### PR TITLE
Fixed a bug in the regular expression regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ const const email: RegExp<(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?
 
 To avoid confusion, you can use any spelling that you want, such as 'Regex' or 'RegularExpression'.
 
-For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]xp?(ression)?/`.
+For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]x(pression|p)/`.
 
 ## Previous
 The `previous` keyword lets you see into the past!<br>

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ const const email: RegExp<(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?
 
 To avoid confusion, you can use any spelling that you want, such as 'Regex' or 'RegularExpression'.
 
-For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]x(pression|p)/`.
+For simplicity, all supported regular expressions match the regular expression `/Reg(ular)?[eE]x(pression|p)?/`.
 
 ## Previous
 The `previous` keyword lets you see into the past!<br>


### PR DESCRIPTION
The regex for handling the spellings of regular expressions is currently `/Reg(ular)?[eE]xp?(ression)?/`, but this allows `RegularExression` to pass.

I propose changing it to `/Reg(ular)?[eE]x(pression|p)/`, which would fix this bug.

Thank you for your time, and I commend this request to the repo.