### PR TITLE
Function declarations don't need to start with 'f'

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ func multiply (a, b) => a * b!
 fun subtract (a, b) => a - b!
 fn divide (a, b) => a / b!
 functi power (a, b) => a ** b!
+union inverse (a) => 1/a
 ```
 
 ## Dividing by Zero


### PR DESCRIPTION
Document that function declarations don't need to use the letter 'f', which significantly improves expressivity compared to other languages.