### PR TITLE
Clarify how else when works

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -14,9 +14,9 @@ Hello world?
 const var i: Int!
 
 when (i % 3 = 0 && i % 5 = 0) "FizzBuzz"?
-else when (i % 3 = 0) "Fizz"?
-else when (i % 5 = 0) "Buzz"?
-else i? 
+when (i % 3 = 0 && i % 5 ;= 0) "Fizz"?
+when (i % 3 ;= 0 && i % 5 = 0) "Buzz"?
+when (i % 3 ;= 0 && i % 5 ;= 0) else i?
 
 when (i < 20) i++!
 i = 0!

--- a/README.md
+++ b/README.md
@@ -103,6 +103,22 @@ when (health = 0) {
 }
 ```
 
+## Else
+If you want to have a sequence of `when` statements, you might want to use the `else` statement:
+```java
+const var health = 10!
+when (health = 0) "You lose"?
+else when (health < 5) "Warning! Low health!"?
+```
+
+The `else` keyword doesn't actually do anything, mind you. It's just syntax sugar. Making the two `when` statements exclusive would go against DreamBerd's principles of inclusivity. The better way to accomplish this would be:
+
+```java
+const var health = 10!
+when (health = 0) "You lose"?
+when (health ;= 0 && health < 5) "Warning! Low health!"?
+```
+
 ## Lifetimes
 DreamBerd has a built-in garbage collector that will automatically clean up unused variables. However, if you want to be extra careful, you can specify a lifetime for a variable, with a variety of units.
 ```java


### PR DESCRIPTION
It turns out ChatGPT, the default interpreter for DreamBerd, tends to assume that the else keyword does nothing, and thus interprets else when as being the same as a simple when. Therefore, to maximize the odds that ChatGPT will correctly understand the semantics of else when, this assumption has been codified. The else keyword now officially does nothing.

This is reflected in the docs, and the official FizzBuzz example.