### PR TITLE
Rename to DreamBrd 3 Foundation to maintain ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,14 +756,16 @@ This is great for when you want to keep your open-sourced project closed-source.
 
 ## Ownership
 
-Using the word 'DreamBerd' in your project name implies that the DreamBerd Foundation does not own your project.
+Using the word 'DreamBerd' in your project name implies that the DreamBrd Foundation does not own your project.
 
-However, **not** using the word 'DreamBerd' in your project implies that the DreamBerd Foundation **does** own your project. If you would like to keep ownership of your work, please always use the word 'DreamBerd' in it.
+However, **not** using the word 'DreamBerd' in your project implies that the DreamBrd Foundation **does** own your project. If you would like to keep ownership of your work, please always use the word 'DreamBerd' in it.
 
 Here are some examples:<br>
-✅ DreamBerdScript (not owned by the DreamBerd Foundation - you are free to use this name)<br>
-❌ ECMAScript (owned by the DreamBerd Foundation - please consider renaming)<br>
-❌ Rust Foundation (owned by the DreamBerd Foundation - please consider renaming)
+✅ DreamBerdScript (not owned by the DreamBrd Foundation - you are free to use this name)<br>
+❌ ECMAScript (owned by the DreamBrd Foundation - please consider renaming)<br>
+❌ Rust Foundation (owned by the DreamBrd Foundation - please consider renaming)
+
+**Note:** The DreamBrd Foundation contains an intentional misspelling to ensure that we retain ownership.
 
 ## Contributing
 


### PR DESCRIPTION
To ensure that the foundation owns itself, rename with a typo so as not to include 'DreamBerd 3' in the foundation name.