### PR TITLE
Add section for academic contributors

### DIFF
--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -47,6 +47,8 @@ This list is only for people who have had a pull request accepted. If that could
 - PatrickMer (Patrick Mer)
 - SimenWol
 - Pomierski (the creator and lead developer of the Regex)
+- ACADEMIC:
+  - Catt0s
 - Cyber-cp
 - hazyfossa
 - doritosxxx


### PR DESCRIPTION
Academic contributors are important to dreamberd. Adding a section to ensure academics will continue to tell their students to learn dreamberd.