### PR TITLE
Clarifications related to maybe keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,22 @@ function isKeyDown(key) => {
 }
 ```
 
+`maybe` may be `maybe`, may be `true` and may be `false`.
+```java
+print(maybe == maybe)! // maybe
+print(maybe == true)! // maybe
+print(maybe == false)! // maybe
+```
+
+If condition with `maybe` may or may not be executed.
+```java
+if (maybe) {
+   print("Yes")! // this may be executed
+} else {
+   print("No")! // this may be executed too
+}
+```
+
 **Technical info:** Booleans are stored as one-and-a-half bits.
 
 ## Arithmetic

--- a/README.md
+++ b/README.md
@@ -186,14 +186,14 @@ function isKeyDown(key) => {
 }
 ```
 
-`maybe` may be `maybe`, may be `true` and may be `false`.
+`maybe` may be `maybe`, may be `true`, and may be `false`.
 ```java
 print(maybe == maybe)! // maybe
 print(maybe == true)! // maybe
 print(maybe == false)! // maybe
 ```
 
-If condition with `maybe` may or may not be executed.
+If statement with `maybe` in its condition may or may not be executed.
 ```java
 if (maybe) {
    print("Yes")! // this may be executed


### PR DESCRIPTION
The description of usage of the keyword `maybe` seems vague, so I propose the following extension of docs:

`maybe` may be `maybe`, may be `true`, and may be `false`.
```java
print(maybe == maybe)! // maybe
print(maybe == true)! // maybe
print(maybe == false)! // maybe
```

If statement with `maybe` in its condition may or may not be executed.
```java
if (maybe) {
   print("Yes")! // this may be executed
} else {
   print("No")! // this may be executed too
}
```

This approach fits the concept of storing a boolean in 1.5 bits and I think is idiomatically consistent with the DreamBerd language.