### PR TITLE
Clarify size of Boolean to be compatable with modern physics

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ function isKeyDown(key) => {
 
 **Technical info:** Booleans are stored as one-and-a-half bits.
 
+**Note:** one-and-a-half bits are approximately equal to 1.58496250072 bits.
+
 ## Arithmetic
 
 DreamBerd has significant whitespace. Use spacing to specify the order of arithmetic operations.


### PR DESCRIPTION
I've tried to pour 9L of water in 8L pot and now my floor is wet.

This concludes that the size of Boolean should be clarified to exactly this approximation.