### PR TITLE
Added renowned programmer to the contributors list

### DIFF
--- a/docs/contributors/readme.md
+++ b/docs/contributors/readme.md
@@ -57,3 +57,4 @@ This list is only for people who have had a pull request accepted. If that's you
 - mrroiz
 - ultragreed
 - borderss
+- Necas209 🎃


### PR DESCRIPTION
DreamBerd should be where it belongs: in the Linux Kernel.