### PR TITLE
Fix an UNFORGIVABLE typo in the booleans section

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ function isKeyDown(key) => {
 }
 ```
 
-**Technical info:** Booleans are stored as one-and-a-half bits.
+**Technical info:** Booleans are stored as 1.58496250072 bits.
 
 ## Arithmetic
 


### PR DESCRIPTION
In the booleans section of the documentation, a boolean is stated to take up "one-and-a-half bits." However, this is incorrect. A three state boolean would actually take up approximately 1.58496250072 as shown by this math:
<img width="512" height="512" alt="math" src="https://github.com/user-attachments/assets/9dc4b79b-5c19-4d7f-b94b-62e65ed372b7" />

By updating this spec, it will better account for modern technology, and conform with modern sub-bit processing. I hope you will consider my contribution.